### PR TITLE
Fix collection/meeting detail views

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -4,7 +4,7 @@ import api.views
 urlpatterns = [
     url(r'^$', api.views.api_root),
     url(r'^collections/$', api.views.CollectionList.as_view(), name='collection-list'),
-    url(r'^collections/(?P<pk>\w+)/$', api.views.CollectionBaseDetail.as_view(), name='collection-detail'),
+    url(r'^collections/(?P<pk>\w+)/$', api.views.CollectionDetail.as_view(), name='collection-detail'),
     url(r'^collections/(?P<pk>\w+)/groups/$', api.views.CollectionGroupList.as_view(), name='collection-group-list'),
     url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/$', api.views.GroupDetail.as_view(), name='collection-group-detail'),
     url(r'^collections/(?P<pk>\w+)/groups/(?P<group_id>\w+)/items/$', api.views.GroupItemList.as_view(), name='group-item-list'),
@@ -23,7 +23,7 @@ urlpatterns = [
     url(r'^users/(?P<user_id>\w+)/$', api.views.UserDetail.as_view(), name='user-detail'),
 
     url(r'^meetings/$', api.views.MeetingList.as_view(), name='meeting-list'),
-    url(r'^meetings/(?P<pk>\w+)/$', api.views.CollectionBaseDetail.as_view(), name='meeting-detail'),
+    url(r'^meetings/(?P<pk>\w+)/$', api.views.MeetingDetail.as_view(), name='meeting-detail'),
     url(r'^meetings/(?P<pk>\w+)/groups/$', api.views.CollectionGroupList.as_view(), name='meeting-group-list'),
     url(r'^meetings/(?P<pk>\w+)/groups/(?P<group_id>\w+)/$', api.views.GroupDetail.as_view(), name='meeting-group-detail'),
     url(r'^meetings/(?P<pk>\w+)/groups/(?P<group_id>\w+)/items/$', api.views.GroupItemList.as_view(), name='meeting-group-item-list'),

--- a/api/views.py
+++ b/api/views.py
@@ -32,6 +32,22 @@ class CollectionList(generics.ListCreateAPIView):
         return queryset
 
 
+class CollectionDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Collection.objects.all()
+    serializer_class = CollectionSerializer
+    permission_classes = (
+      drf_permissions.IsAuthenticatedOrReadOnly,
+      CanEditCollection
+    )
+
+    def get_object(self):
+        try:
+            collection = Collection.objects.get(id=self.kwargs['pk'])
+        except ObjectDoesNotExist:
+            raise drf_exceptions.NotFound
+        return collection
+
+
 class MeetingList(generics.ListCreateAPIView):
     """View list of collections and create a new collection. """
     serializer_class = MeetingSerializer
@@ -45,23 +61,17 @@ class MeetingList(generics.ListCreateAPIView):
         return queryset
 
 
-class CollectionBaseDetail(generics.RetrieveUpdateDestroyAPIView):
-    queryset = CollectionBase.objects.all()
+class MeetingDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Meeting.objects.all()
+    serializer_class = MeetingSerializer
     permission_classes = (
       drf_permissions.IsAuthenticatedOrReadOnly,
       CanEditCollection
     )
 
-    def get_serializer_class(self):
-        collection = self.get_object()
-        if collection.type == 'api.meeting':
-            return MeetingSerializer
-        else:
-            return CollectionSerializer
-
     def get_object(self):
         try:
-            collection = CollectionBase.objects.get(id=self.kwargs['pk'])
+            collection = Meeting.objects.get(id=self.kwargs['pk'])
         except ObjectDoesNotExist:
             raise drf_exceptions.NotFound
         return collection


### PR DESCRIPTION
Create separate detail views for meetings and collections. Overriding get_serializer_class causes an issue when trying to delete a meeting or collection.