### PR TITLE
Feature/api documentation [OC-129]

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -133,7 +133,7 @@ class ItemSerializer(serializers.Serializer):
 class GroupSerializer(serializers.Serializer):
     id = serializers.CharField(read_only=True)
     title = serializers.CharField(required=True)
-    description = serializers.CharField(allow_blank=True)
+    description = serializers.CharField(allow_blank=True, required=False)
     created_by = UserSerializer(read_only=True)
     date_created = serializers.DateTimeField(read_only=True)
     date_updated = serializers.DateTimeField(read_only=True)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -170,8 +170,8 @@ class GroupSerializer(serializers.Serializer):
 class CollectionSerializer(serializers.Serializer):
     id = serializers.CharField(read_only=True)
     title = serializers.CharField(required=True)
-    description = serializers.CharField(allow_blank=True)
-    tags = serializers.CharField(allow_blank=True)
+    description = serializers.CharField(required=False, allow_blank=True)
+    tags = serializers.CharField(required=False, allow_blank=True)
     settings = serializers.JSONField(required=False)
     submission_settings = serializers.JSONField(required=False)
     created_by_org = serializers.CharField(allow_blank=True, required=False)

--- a/api/views.py
+++ b/api/views.py
@@ -564,6 +564,56 @@ class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class CurrentUser(generics.RetrieveUpdateDestroyAPIView):
+    """ Details about the currently logged-in user.
+
+    ## User Attributes
+
+        name                          type                    description
+        ======================================================================================================
+        username                      string                  username for the user
+        first_name                    string                  first name of the user
+        last_name                     string                  last name of the user
+        email                         string                  email address associated with the user's account
+        date_joined                   iso8601 timestamp       date/time of account creation
+        last_login                    iso8601 timestamp       date/time of last login
+        is_active                     boolean                 whether the user account is active
+        gravatar                      string                  link to user gravatar
+        token                         string                  access token for social account (used for OAUTH)
+
+    ## Actions
+
+    ###Update
+
+            Method:        PUT / PATCH
+            URL:           /api/users/<user_id>
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "users",                       # required
+                               "id":   {user_id},                     # required
+                               "attributes": {
+                                 "username":       {username},        # required
+                                 "first_name":     {first_name},      # optional
+                                 "last_name":      {last_name},       # optional
+                                 "email":          {email}            # optional
+                                 "date_joined":    {date_joined}      # optional
+                                 "last_login":     {last_login}       # optional
+                                 "is_active":      {is_active}        # optional
+                                 "gravatar":       {gravatar}         # optional
+                               }
+                             }
+                           }
+            Success:       200 OK + user representation
+
+    ###Delete
+            Method:   DELETE
+            URL:      /api/users/<user_id>
+            Params:   <none>
+            Success:  204 No Content
+
+    #This Request/Response
+
+    """
     queryset = User.objects.all()
     serializer_class = UserSerializer
 
@@ -572,7 +622,25 @@ class CurrentUser(generics.RetrieveUpdateDestroyAPIView):
 
 
 class UserList(generics.ListAPIView):
-    """View list of users. """
+    """ View list of users.
+
+    ## User Attributes
+
+        name                          type                    description
+        ======================================================================================================
+        username                      string                  username for the user
+        first_name                    string                  first name of the user
+        last_name                     string                  last name of the user
+        email                         string                  email address associated with the user's account
+        date_joined                   iso8601 timestamp       date/time of account creation
+        last_login                    iso8601 timestamp       date/time of last login
+        is_active                     boolean                 whether the user account is active
+        gravatar                      string                  link to user gravatar
+        token                         string                  access token for social account (used for OAUTH)
+
+    #This Request/Response
+
+    """
     serializer_class = UserSerializer
     # permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
 
@@ -581,7 +649,55 @@ class UserList(generics.ListAPIView):
 
 
 class UserDetail(generics.RetrieveUpdateDestroyAPIView):
-    """View user detail. """
+    """ Details about a given user.
+
+    ## User Attributes
+
+        name                          type                    description
+        ======================================================================================================
+        username                      string                  username for the user
+        first_name                    string                  first name of the user
+        last_name                     string                  last name of the user
+        email                         string                  email address associated with the user's account
+        date_joined                   iso8601 timestamp       date/time of account creation
+        last_login                    iso8601 timestamp       date/time of last login
+        is_active                     boolean                 whether the user account is active
+        gravatar                      string                  link to user gravatar
+        token                         string                  access token for social account (used for OAUTH)
+
+    ## Actions
+
+    ###Update
+
+            Method:        PUT / PATCH
+            URL:           /api/users/<user_id>
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "users",                       # required
+                               "id":   {user_id},                     # required
+                               "attributes": {
+                                 "username":       {username},        # required
+                                 "first_name":     {first_name},      # optional
+                                 "last_name":      {last_name},       # optional
+                                 "email":          {email}            # optional
+                                 "date_joined":    {date_joined}      # optional
+                                 "last_login":     {last_login}       # optional
+                                 "is_active":      {is_active}        # optional
+                                 "gravatar":       {gravatar}         # optional
+                               }
+                             }
+                           }
+            Success:       200 OK + user representation
+
+    ###Delete
+            Method:   DELETE
+            URL:      /api/users/<user_id>
+            Params:   <none>
+            Success:  204 No Content
+
+    #This Request/Response
+    """
     serializer_class = UserSerializer
     # permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
 

--- a/api/views.py
+++ b/api/views.py
@@ -353,6 +353,7 @@ class CollectionGroupList(generics.ListCreateAPIView):
 
 
 class GroupList(generics.ListCreateAPIView):
+    #TODO: Consider making this endpoint a ListAPIView
     serializer_class = GroupSerializer
     permission_classes = (
       drf_permissions.IsAuthenticatedOrReadOnly,
@@ -370,6 +371,59 @@ class GroupList(generics.ListCreateAPIView):
 
 
 class GroupDetail(generics.RetrieveUpdateDestroyAPIView):
+    """ Details about a given group.
+
+    ## Group Attributes
+
+        name                          type                    description
+        =================================================================================================================
+        title                         string                  group title
+        description                   string                  group description
+        date_created                  iso8601 timestamp       date/time when the group was created
+        date_updated                  iso8601 timestamp       date/time when the group was last updated
+
+    ##Relationships
+
+    ### Items
+
+    List of items that belong to this group.
+
+    ### Created By
+
+    User who created this group.
+
+    ## Actions
+
+    ###Update
+
+            Method:        PUT / PATCH
+            URL:           /api/collections/<collection_id>/groups/<group_id> OR
+                           /api/meetings/<meeting_id>/groups/<group_id>
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "groups",                            # required
+                               "id":   {group_id},                          # required
+                               "attributes": {
+                                 "title":               {title},            # required
+                                 "description":         {description}       # optional
+                               }
+                             }
+                           }
+            Success:       200 OK + group representation
+
+    Note: The `title` is required with PUT requests and optional with PATCH requests.
+
+    ###Delete
+            Method:   DELETE
+            URL:      /api/collections/<collection_id>/groups/<group_id> OR
+                      /api/meetings/<meeting_id>/groups/<group_id>
+            Params:   <none>
+            Success:  204 No Content
+
+    #This Request/Response
+
+    """
     serializer_class = GroupSerializer
     queryset = Group.objects.all()
     permission_classes = (
@@ -524,6 +578,7 @@ class GroupItemList(generics.ListCreateAPIView):
 
 
 class ItemList(generics.ListCreateAPIView):
+    #TODO: Consider making this endpoint a ListAPIView
     serializer_class = ItemSerializer
     permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
 
@@ -543,6 +598,73 @@ class ItemList(generics.ListCreateAPIView):
 
 
 class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
+    """ Details for a given item.
+
+    ## Item Attributes
+
+        name                          type                    description
+        ================================================================================================================
+        title                         string                  item title
+        description                   string                  item description
+        type                          string                  type of item (e.g. 'project', 'presentation', etc.)
+        status                        string                  moderation status ('approved', 'pending', 'rejected')
+        source_id                     string                  guid of associated OSF object (e.g. node_id for an OSF project)
+        url                           string                  url of associated OSF object (e.g. project url)
+        metadata                      object                  additional information about the item
+        date_created                  iso8601 timestamp       date/time when the item was created
+        date_submitted                iso8601 timestamp       date/time when the item was submitted
+        date_accepted                 iso8601 timestamp       date/time when the item was accepted
+        location                      string                  location of the event item
+        start_time                    iso8601 timestamp       date/time when the event item begins
+        end_time                      iso8601 timestamp       date/time when the event item ends
+        category                      string                  item category (e.g. 'talk', 'poster')
+
+    ##Relationships
+
+    ### Created By
+
+    User who created this item.
+
+    ## Actions
+
+    ###Update
+
+            Method:        PUT / PATCH
+            URL:           /api/collections/<collection_id>/groups/<group_id>/items/<item_id> OR
+                           /api/meetings/<meeting_id>/groups/<group_id>/items/<item_id>
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "items",                  # required
+                               "attributes": {
+                                 "title":       {title},         # required
+                                 "description": {description},   # optional
+                                 "type":        {type},          # required
+                                 "status":      {status},        # required
+                                 "source_id":   {source_id},     # optional
+                                 "url":         {url},           # optional
+                                 "metadata":    {metadata},      # optional
+                                 "location":    {location},      # optional
+                                 "start_time":  {start_time},    # optional
+                                 "end_time":    {end_time},      # optional
+                                 "category":    {category}       # required
+                               }
+                             }
+                           }
+            Success:       200 OK + item representation
+
+    Note: The `title`, `type`, `status` and `category` fields are required for PUT and optional for PATCH requests.
+
+    ###Delete
+            Method:   DELETE
+            URL:      /api/collections/<collection_id>/groups/<group_id>/items/<item_id> OR
+                      /api/meetings/<meeting_id>/groups/<group_id>/items/<item_id>
+            Params:   <none>
+            Success:  204 No Content
+
+    #This Request/Response
+
+    """
     serializer_class = ItemSerializer
     queryset = Item.objects.all()
     permission_classes = (

--- a/api/views.py
+++ b/api/views.py
@@ -434,6 +434,10 @@ class CollectionItemList(generics.ListCreateAPIView):
                            }
             Success:       201 CREATED + item representation
 
+    Note: Items added by the collection creator will automatically have the status "approved". If "approve_all" is true
+    in collection.settings, items added by other users will automatically have the status "approved", otherwise
+    they will be "pending".
+
     #This Request/Response
     """
     serializer_class = ItemSerializer
@@ -498,6 +502,10 @@ class GroupItemList(generics.ListCreateAPIView):
                              }
                            }
             Success:       201 CREATED + item representation
+
+    Note: Items added by the collection creator will automatically have the status "approved". If "approve_all" is true
+    in collection.settings, items added by other users will automatically have the status "approved", otherwise
+    they will be "pending".
 
     #This Request/Response
     """

--- a/api/views.py
+++ b/api/views.py
@@ -304,6 +304,38 @@ class MeetingDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class CollectionGroupList(generics.ListCreateAPIView):
+    """ List of groups in a given collection/meeting.
+
+    ## Group Attributes
+
+        name                          type                    description
+        =================================================================================================================
+        title                         string                  group title
+        description                   string                  group description
+        date_created                  iso8601 timestamp       date/time when the group was created
+        date_updated                  iso8601 timestamp       date/time when the group was last updated
+
+    ## Actions
+
+    ### Creating New Groups
+
+            Method:        POST
+            URL:           /api/collections/<collection_id>/groups OR /api/meetings/<meeting_id>/groups
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "groups",                 # required
+                               "attributes": {
+                                 "title":        {title},        # required
+                                 "description":  {description},  # optional
+                               }
+                             }
+                           }
+            Success:       201 CREATED + group representation
+
+    #This Request/Response
+
+    """
     permission_classes = (
       drf_permissions.IsAuthenticatedOrReadOnly,
       CanEditGroup

--- a/api/views.py
+++ b/api/views.py
@@ -20,7 +20,49 @@ def api_root(request):
 
 
 class CollectionList(generics.ListCreateAPIView):
-    """View list of collections and create a new collection. """
+    """View list of collections and create a new collection.
+
+    ## Collection Attributes
+
+        name                          type                    description
+        =================================================================================================================
+        title                         string                  collection title
+        description                   string                  collection description
+        tags                          string                  tags describing the collection
+        settings                      object                  general settings for the collection (e.g. collection_type)
+        submission_settings           object                  settings for the collection's submission form
+        created_by_org                string                  the organization/institution associated with the collection
+        date_created                  iso8601 timestamp       date/time when the collection was created
+        date_updated                  iso8601 timestamp       date/time when the collection was last updated
+
+    ## Actions
+
+    ### Creating New Collections
+
+        Method:        POST
+            URL:           /api/collections
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "collections", # required
+                               "attributes": {
+                                 "title":               {title},              # required
+                                 "description":         {description},        # optional
+                                 "tags":                {tag1, tag2, },       # optional
+                                 "created_by_org":      {created_by_org}      # optional
+                                 "settings":            {settings}            # optional
+                                 "submission_settings": {submission_settings} # optional
+                               }
+                             }
+                           }
+            Success:       201 CREATED + collection representation
+
+    ## Query Params
+    +  `title=<Str>`: filters collections by title
+
+    #This Request/Response
+
+    """
     serializer_class = CollectionSerializer
     permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
 

--- a/api/views.py
+++ b/api/views.py
@@ -44,7 +44,7 @@ class CollectionList(generics.ListCreateAPIView):
             Query Params:  <none>
             Body (JSON):   {
                              "data": {
-                               "type": "collections", # required
+                               "type": "collections",                         # required
                                "attributes": {
                                  "title":               {title},              # required
                                  "description":         {description},        # optional
@@ -154,7 +154,57 @@ class CollectionDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class MeetingList(generics.ListCreateAPIView):
-    """View list of collections and create a new collection. """
+    """ View list of meetings and create a new meeting.
+
+    ## Meeting Attributes
+
+        name                          type                    description
+        =================================================================================================================
+        title                         string                  meeting title
+        description                   string                  meeting description
+        tags                          string                  tags describing the meeting
+        settings                      object                  general settings for the meeting (e.g. collection_type)
+        submission_settings           object                  settings for the meeting's submission form
+        created_by_org                string                  the organization/institution associated with the meeting
+        date_created                  iso8601 timestamp       date/time when the meeting was created
+        date_updated                  iso8601 timestamp       date/time when the meeting was last updated
+        location                      string                  location of the meeting
+        address                       string                  street address of the meeting location
+        start_date                    iso8601 timestamp       date/time when the meeting begins
+        end_date                      iso8601 timestamp       date/time when the meeting ends
+
+    ## Actions
+
+    ### Creating New Meetings
+
+            Method:        POST
+            URL:           /api/meetings
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "meetings",                            # required
+                               "attributes": {
+                                 "title":               {title},              # required
+                                 "description":         {description},        # optional
+                                 "tags":                {tag1, tag2, },       # optional
+                                 "created_by_org":      {created_by_org}      # optional
+                                 "settings":            {settings}            # optional
+                                 "submission_settings": {submission_settings} # optional
+                                 "location":            {location}            # optional
+                                 "address":             {address}             # optional
+                                 "start_date":          {start_date}          # optional
+                                 "end_date":            {end_date}            # optional
+                               }
+                             }
+                           }
+            Success:       201 CREATED + meeting representation
+
+    ## Query Params
+    +  `title=<Str>`: filters meetings by title
+
+    #This Request/Response
+
+    """
     serializer_class = MeetingSerializer
     permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
 

--- a/api/views.py
+++ b/api/views.py
@@ -304,7 +304,7 @@ class MeetingDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class CollectionGroupList(generics.ListCreateAPIView):
-    """ List of groups in a given collection/meeting.
+    """ View list of groups in a given collection/meeting, or create a new group in a given collection/meeting.
 
     ## Group Attributes
 
@@ -386,6 +386,56 @@ class GroupDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class CollectionItemList(generics.ListCreateAPIView):
+    """ View list of items in a given collection/meeting, or create a new item in a given collection/meeting.
+
+    ## Item Attributes
+
+        name                          type                    description
+        ================================================================================================================
+        title                         string                  item title
+        description                   string                  item description
+        type                          string                  type of item (e.g. 'project', 'presentation', etc.)
+        status                        string                  moderation status ('approved', 'pending', 'rejected')
+        source_id                     string                  guid of associated OSF object (e.g. node_id for an OSF project)
+        url                           string                  url of associated OSF object (e.g. project url)
+        metadata                      object                  additional information about the item
+        date_created                  iso8601 timestamp       date/time when the item was created
+        date_submitted                iso8601 timestamp       date/time when the item was submitted
+        date_accepted                 iso8601 timestamp       date/time when the item was accepted
+        location                      string                  location of the event item
+        start_time                    iso8601 timestamp       date/time when the event item begins
+        end_time                      iso8601 timestamp       date/time when the event item ends
+        category                      string                  item category (e.g. 'talk', 'poster')
+
+    ## Actions
+
+    ### Creating New Items
+
+            Method:        POST
+            URL:           /api/collections/<collection_id>/items OR /api/meetings/<meeting_id>/items
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "items",                  # required
+                               "attributes": {
+                                 "title":       {title},         # required
+                                 "description": {description},   # optional
+                                 "type":        {type},          # required
+                                 "status":      {status},        # required
+                                 "source_id":   {source_id},     # optional
+                                 "url":         {url},           # optional
+                                 "metadata":    {metadata},      # optional
+                                 "location":    {location},      # optional
+                                 "start_time":  {start_time},    # optional
+                                 "end_time":    {end_time},      # optional
+                                 "category":    {category}       # required
+                               }
+                             }
+                           }
+            Success:       201 CREATED + item representation
+
+    #This Request/Response
+    """
     serializer_class = ItemSerializer
     permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
 
@@ -400,7 +450,58 @@ class CollectionItemList(generics.ListCreateAPIView):
 
 
 class GroupItemList(generics.ListCreateAPIView):
-    """View items in a collection and create a new item to add to the collection. """
+    """ View list of items or create a new item in a given group.
+
+    ## Item Attributes
+
+        name                          type                    description
+        ================================================================================================================
+        title                         string                  item title
+        description                   string                  item description
+        type                          string                  type of item (e.g. 'project', 'presentation', etc.)
+        status                        string                  moderation status ('approved', 'pending', 'rejected')
+        source_id                     string                  guid of associated OSF object (e.g. node_id for an OSF project)
+        url                           string                  url of associated OSF object (e.g. project url)
+        metadata                      object                  additional information about the item
+        date_created                  iso8601 timestamp       date/time when the item was created
+        date_submitted                iso8601 timestamp       date/time when the item was submitted
+        date_accepted                 iso8601 timestamp       date/time when the item was accepted
+        location                      string                  location of the event item
+        start_time                    iso8601 timestamp       date/time when the event item begins
+        end_time                      iso8601 timestamp       date/time when the event item ends
+        category                      string                  item category (e.g. 'talk', 'poster')
+
+    ## Actions
+
+    ### Creating New Items
+
+            Method:        POST
+            URL:           /api/collections/<collection_id>/groups/<group_id>/items OR
+                           /api/meetings/<meeting_id>/groups/<group_id>/items
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "items",                  # required
+                               "attributes": {
+                                 "title":       {title},         # required
+                                 "description": {description},   # optional
+                                 "type":        {type},          # required
+                                 "status":      {status},        # required
+                                 "source_id":   {source_id},     # optional
+                                 "url":         {url},           # optional
+                                 "metadata":    {metadata},      # optional
+                                 "location":    {location},      # optional
+                                 "start_time":  {start_time},    # optional
+                                 "end_time":    {end_time},      # optional
+                                 "category":    {category}       # required
+                               }
+                             }
+                           }
+            Success:       201 CREATED + item representation
+
+    #This Request/Response
+    """
+
     serializer_class = ItemSerializer
     permission_classes = (drf_permissions.IsAuthenticatedOrReadOnly, )
 

--- a/api/views.py
+++ b/api/views.py
@@ -116,7 +116,7 @@ class CollectionDetail(generics.RetrieveUpdateDestroyAPIView):
                                "type": "collections",   # required
                                "id":   {collection_id}, # required
                                "attributes": {
-                                 "title":               {title},              # required for PUT
+                                 "title":               {title},              # required
                                  "description":         {description},        # optional
                                  "tags":                {tag1, tag2, },       # optional
                                  "created_by_org":      {created_by_org}      # optional
@@ -217,6 +217,77 @@ class MeetingList(generics.ListCreateAPIView):
 
 
 class MeetingDetail(generics.RetrieveUpdateDestroyAPIView):
+    """ Details about a given meeting.
+
+     ## Meeting Attributes
+
+        name                          type                    description
+        =================================================================================================================
+        title                         string                  meeting title
+        description                   string                  meeting description
+        tags                          string                  tags describing the meeting
+        settings                      object                  general settings for the meeting (e.g. collection_type)
+        submission_settings           object                  settings for the meeting's submission form
+        created_by_org                string                  the organization/institution associated with the meeting
+        date_created                  iso8601 timestamp       date/time when the meeting was created
+        date_updated                  iso8601 timestamp       date/time when the meeting was last updated
+        location                      string                  location of the meeting
+        address                       string                  street address of the meeting location
+        start_date                    iso8601 timestamp       date/time when the meeting begins
+        end_date                      iso8601 timestamp       date/time when the meeting ends
+
+    ##Relationships
+
+    ### Groups
+
+    List of groups that belong to this meeting.
+
+    ### Items
+
+    List of top-level items that belong to this meeting.
+
+    ### Created By
+
+    User who created this meeting.
+
+    ## Actions
+
+    ###Update
+
+            Method:        PUT / PATCH
+            URL:           /api/meeting/<meeting_id>
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "meetings",                            # required
+                               "id":   {meeting_id},                          # required
+                               "attributes": {
+                                 "title":               {title},              # required for PUT
+                                 "description":         {description},        # optional
+                                 "tags":                {tag1, tag2, },       # optional
+                                 "created_by_org":      {created_by_org}      # optional
+                                 "settings":            {settings}            # optional
+                                 "submission_settings": {submission_settings} # optional
+                                 "location":            {location}            # optional
+                                 "address":             {address}             # optional
+                                 "start_date":          {start_date}          # optional
+                                 "end_date":            {end_date}            # optional
+                               }
+                             }
+                           }
+            Success:       200 OK + meeting representation
+
+    Note: The `title` is required with PUT requests and optional with PATCH requests.
+
+    ###Delete
+            Method:   DELETE
+            URL:      /api/meetings/<meeting_id>
+            Params:   <none>
+            Success:  204 No Content
+
+    #This Request/Response
+    """
+
     queryset = Meeting.objects.all()
     serializer_class = MeetingSerializer
     permission_classes = (

--- a/api/views.py
+++ b/api/views.py
@@ -20,7 +20,7 @@ def api_root(request):
 
 
 class CollectionList(generics.ListCreateAPIView):
-    """View list of collections and create a new collection.
+    """ View list of collections and create a new collection.
 
     ## Collection Attributes
 
@@ -39,7 +39,7 @@ class CollectionList(generics.ListCreateAPIView):
 
     ### Creating New Collections
 
-        Method:        POST
+            Method:        POST
             URL:           /api/collections
             Query Params:  <none>
             Body (JSON):   {
@@ -75,6 +75,69 @@ class CollectionList(generics.ListCreateAPIView):
 
 
 class CollectionDetail(generics.RetrieveUpdateDestroyAPIView):
+    """ Details about a given collection.
+
+    ## Collection Attributes
+
+        name                          type                    description
+        =================================================================================================================
+        title                         string                  collection title
+        description                   string                  collection description
+        tags                          string                  tags describing the collection
+        settings                      object                  general settings for the collection (e.g. collection_type)
+        submission_settings           object                  settings for the collection's submission form
+        created_by_org                string                  the organization/institution associated with the collection
+        date_created                  iso8601 timestamp       date/time when the collection was created
+        date_updated                  iso8601 timestamp       date/time when the collection was last updated
+
+    ##Relationships
+
+    ### Groups
+
+    List of groups that belong to this collection.
+
+    ### Items
+
+    List of top-level items that belong to this collection.
+
+    ### Created By
+
+    User who created this collection.
+
+    ## Actions
+
+    ###Update
+
+            Method:        PUT / PATCH
+            URL:           /api/collections/<collection_id>
+            Query Params:  <none>
+            Body (JSON):   {
+                             "data": {
+                               "type": "collections",   # required
+                               "id":   {collection_id}, # required
+                               "attributes": {
+                                 "title":               {title},              # required for PUT
+                                 "description":         {description},        # optional
+                                 "tags":                {tag1, tag2, },       # optional
+                                 "created_by_org":      {created_by_org}      # optional
+                                 "settings":            {settings}            # optional
+                                 "submission_settings": {submission_settings} # optional
+                               }
+                             }
+                           }
+            Success:       200 OK + collection representation
+
+    Note: The `title` is required with PUT requests and optional with PATCH requests.
+
+    ###Delete
+            Method:   DELETE
+            URL:      /api/collections/<collection_id>
+            Params:   <none>
+            Success:  204 No Content
+
+    #This Request/Response
+
+    """
     queryset = Collection.objects.all()
     serializer_class = CollectionSerializer
     permission_classes = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ inflection==0.3.1
 ipdb==0.10.2
 ipython==5.3.0
 ipython-genutils==0.1.0
+Markdown==2.4.1
 nose==1.3.7
 oauthlib==1.0.3
 pexpect==4.2.1


### PR DESCRIPTION
Add documentation to API views 

Note this does not include documentation on top-level group and item endpoints (`api/groups/` and `api/items/`, since those need more testing