### PR TITLE
Feature/fix item admin [OC-142]

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -21,17 +21,16 @@ class CollectionBase(TypedModel):
     settings = JSONField(default={})
     submission_settings = JSONField(default={})
 
-    class Meta:
-        permissions = (
-            ('approve_items', 'Approve items'),
-        )
-
     def __str__(self):
         return self.title
 
 
 class Collection(CollectionBase):
-    pass
+
+    class Meta:
+        permissions = (
+            ('approve_collection_items', 'Approve collection items'),
+        )
 
 
 class Meeting(CollectionBase):
@@ -39,6 +38,11 @@ class Meeting(CollectionBase):
     address = models.CharField(null=True, blank=True, default=None, max_length=200)
     start_date = models.DateTimeField(null=True, blank=True, default=None)
     end_date = models.DateTimeField(null=True, blank=True, default=None)
+
+    class Meta:
+        permissions = (
+            ('approve_meeting_items', 'Approve meeting items'),
+        )
 
 
 class Group(models.Model):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -70,7 +70,7 @@ class ItemSerializer(serializers.Serializer):
                 raise ValueError('Collection only accepts items of type ' + collection_type)
 
         status = 'pending'
-        if user.has_perm('api.approve_items', collection) or allow_all:
+        if user.has_perm(['api.approve_collection_items', 'api.approve_meeting_items'], collection) or allow_all:
             status = 'approved'
             validated_data['date_accepted'] = timezone.now()
 
@@ -199,7 +199,7 @@ class CollectionSerializer(serializers.Serializer):
     def create(self, validated_data):
         user = self.context['request'].user
         collection = Collection.objects.create(created_by=user, **validated_data)
-        assign_perm('api.approve_items', user, collection)
+        assign_perm('api.approve_collection_items', user, collection)
         return collection
 
     def update(self, collection, validated_data):
@@ -236,7 +236,7 @@ class MeetingSerializer(CollectionSerializer):
     def create(self, validated_data):
         user = self.context['request'].user
         meeting = Meeting.objects.create(created_by=user, **validated_data)
-        assign_perm('api.approve_items', user, meeting)
+        assign_perm('api.approve_meeting_items', user, CollectionBase(meeting))
         return meeting
 
     def update(self, meeting, validated_data):


### PR DESCRIPTION
- Create separate permission classes for approving meeting vs. collection items
  (django guardian has a limitation where an object-level permission class cannot be used for more than one model)
- Update the item admin model to get collections and meeting items that the user has permission
  to change the status for