### PR TITLE
Update component names to match frontend changes

### DIFF
--- a/tests/resources.py
+++ b/tests/resources.py
@@ -10,42 +10,42 @@ meeting_json = {
     "layers": [
         {
             "sectionHeader": "Landing Title",
-            "component": "landing-title",
+            "component": "section-title",
             "settings": {}
         },
         {
             "sectionHeader": "Paragraph",
-            "component": "landing-paragraph",
+            "component": "section-paragraph",
             "settings": {
                 "body": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?"
             }
         },
         {
             "sectionHeader": "File Grid",
-            "component": "dataset-file-grid",
+            "component": "section-file-grid",
             "settings": {}
         },
         {
             "sectionHeader": "Splash Image",
-            "component": "landing-splash-image",
+            "component": "section-splash-image",
             "settings": {}
 
         },
         {
             "sectionHeader": "Splash Image",
-            "component": "contributor-list",
+            "component": "section-contributors",
             "settings": {
                 "background-color": "#fff"
             }
         },
         {
             "sectionHeader": "Schedule",
-            "component": "meeting-schedule",
+            "component": "section-schedule",
             "settings": {}
         },
         {
             "sectionHeader": "Items",
-            "component": "item-table",
+            "component": "section-item-table",
             "settings": {
                 "header-color": "#444",
                 "text-color": "#fff"
@@ -53,7 +53,7 @@ meeting_json = {
         },
         {
             "sectionHeader": "Sponsors",
-            "component": "landing-sponsors",
+            "component": "section-sponsors",
             "settings": {
                 "title": "Sponsors",
                 "data": "sponsor-categories",
@@ -63,7 +63,7 @@ meeting_json = {
         },
         {
             "sectionHeader": "Code of Conduct",
-            "component": "landing-paragraph",
+            "component": "section-paragraph",
             "settings": {
                 "title": "Code of Conduct",
                 "body": "At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.",
@@ -193,130 +193,24 @@ dataset_json = {
     },
     "layout": [
         {
-            "type": "landing-title",
+            "type": "section-title",
         },
         {
-            "type": "landing-paragraph",
+            "type": "section-paragraph",
             "body": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?"
         },
         {
-            "type": "landing-splash-image"
+            "type": "section-splash-image"
         },
         {
-            "type": "contributor-list",
+            "type": "section-contributors",
             "data": "speakers",
             "background-color": "#fff"
         },
         {
-            "type": "item-table",
+            "type": "section-item-table",
             "header-color": "#444",
             "text-color": "#fff"
         }
-    ],
-    "data": {
-        "presentations": [
-            {
-                "img-url": "http://placehold.it/32x32",
-                "presenter": "Rasmussen Bruce",
-                "title": "mollit tempor eiusmod pariatur aliqua eiusmod irure nostrud cupidatat nisi"
-            }
-        ],
-        "sponsorCategories": [
-            {
-                "category": "Gold",
-                "sponsors": [
-                    {
-                        "name": "Accenture",
-                        "website-url": "http://accenture.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/accenture-logo-199.png"
-                    },
-                    {
-                        "name": "Capital One",
-                        "website-url": "http://jobs.capitalone.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/capital-one-300.png"
-                    },
-                    {
-                        "name": "Google",
-                        "website-url": "http://google.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/google-new-302-300x99.png"
-                    },
-                    {
-                        "name": "Microsoft",
-                        "website-url": "http://microsoft.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/new-microsoft.jpg"
-                    }
-                ]
-            },
-            {
-                "category": "Silver",
-                "sponsors": [
-                    {
-                        "name": "Amazon",
-                        "website-url": "http://amazon.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/amazon-160.png "
-                    },
-                    {
-                        "name": "Qualcomm",
-                        "website-url": "http://qualcomm.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/qualcomm-logo-185.png"
-                    },
-                    {
-                        "name": "LinkedIn",
-                        "website-url": "http://linkedin.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/linkedin-160.png "
-                    },
-                    {
-                        "name": "Yahoo",
-                        "website-url": "http://yahoo.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/yahoo-168.png"
-                    }
-                ]
-            },
-            {
-                "category": "Bronze",
-                "sponsors": [
-                    {
-                        "name": "Twitter",
-                        "website-url": "http://twitter.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/twitter-88.png"
-                    },
-                    {
-                        "name": "PayPal",
-                        "website-url": "http://paypal.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/paypal-logo-with-name-210.png"
-                    },
-                    {
-                        "name": "Salesforce",
-                        "website-url": "http://salesforce.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/salesforce-96.png"
-                    },
-                    {
-                        "name": "Accenture",
-                        "website-url": "http://accenture.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/accenture-logo-199.png"
-                    },
-                    {
-                        "name": "Amazon",
-                        "website-url": "http://amazon.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/amazon-160.png "
-                    },
-                    {
-                        "name": "Qualcomm",
-                        "website-url": "http://qualcomm.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/qualcomm-logo-185.png"
-                    },
-                    {
-                        "name": "LinkedIn",
-                        "website-url": "http://linkedin.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/linkedin-160.png "
-                    },
-                    {
-                        "name": "Yahoo",
-                        "website-url": "http://yahoo.com",
-                        "img-url": "https://anitaborg.org/wp-content/uploads/2013/09/yahoo-168.png"
-                    }
-                ]
-            }
-        ]
-    }
+    ]
 }

--- a/workflow/schemas/create-proposal.json
+++ b/workflow/schemas/create-proposal.json
@@ -23,7 +23,7 @@
         {
           "label": "Topic",
           "description": "What area of research does this proposal apply to?",
-          "widgetType": "text-field",
+          "widgetType": "widget-text-field",
           "parameters": {
             "value": "topic"
           }
@@ -31,7 +31,7 @@
         {
           "label": "Premise",
           "description": "Describe the basic premise behind the idea.",
-          "widgetType": "text-area",
+          "widgetType": "widget-text-area",
           "parameters": {
             "value": "premise"
           }
@@ -39,7 +39,7 @@
         {
           "label": "Submit",
           "description": "Submit this proposal",
-          "widgetType": "proposal-submit",
+          "widgetType": "widget-proposal-submit",
           "parameters": {
             "premis": "premise",
             "topic": "topic"

--- a/workflow/schemas/dataset.json
+++ b/workflow/schemas/dataset.json
@@ -22,7 +22,7 @@
         {
           "label": "Upload a file",
           "description": "Select the file to upload",
-          "widgetType": "file-uploader",
+          "widgetType": "widget-file-uploader",
           "parameters": {
             "fileData": "file-data",
             "fileName": "file-name"
@@ -31,7 +31,7 @@
         {
           "label": "Title",
           "description": "Enter the title of the file.",
-          "widgetType": "text-field",
+          "widgetType": "widget-text-field",
           "parameters": {
             "value": "title-widget"
           }
@@ -45,7 +45,7 @@
         {
           "label": "Metadata",
           "desciption": "Enter the metadata for the file that is being uploaded",
-          "widgetType": "text-field",
+          "widgetType": "widget-text-field",
           "parameters": {
             "value": "metadata"
           }
@@ -59,7 +59,7 @@
         {
           "label": "Submit",
           "description": "Submit this talk",
-          "widgetType": "meeting-submit",
+          "widgetType": "widget-meeting-submit",
           "parameters": {
             "title": "title-widget",
             "fileData": "file-data",

--- a/workflow/schemas/meeting-approval.json
+++ b/workflow/schemas/meeting-approval.json
@@ -24,7 +24,7 @@
         {
           "label": "",
           "description": "",
-          "widgetType": "item-display",
+          "widgetType": "widget-item-display",
           "parameters": {
             "value": "item"
           }
@@ -32,13 +32,13 @@
       ]
     },
     {
-        "label": "Event Logisitics",
+        "label": "Event Logistics",
         "description": "Set the time and roomfor the event",
         "widgets": [
             {
                 "label": "Room",
                 "description": "What room is the event going to be in?",
-                "widgetType": "text-field",
+                "widgetType": "widget-text-field",
                 "parameters": {
                     "value": "event-room"
                 }
@@ -46,7 +46,7 @@
             {
                 "label": "Start Time",
                 "description": "When does the event start?",
-                "widgetType": "datetime-field",
+                "widgetType": "widget-datetime-field",
                 "parameters": {
                     "date": "start-time"
                 }
@@ -54,7 +54,7 @@
             {
                 "label": "End Time",
                 "description": "When does the event end?",
-                "widgetType": "datetime-field",
+                "widgetType": "widget-datetime-field",
                 "parameters": {
                     "date": "end-time"
                 }
@@ -68,7 +68,7 @@
         {
           "label": "Approve or Deny",
           "description": "Select the resolution \"Approve\" or \"Deny\"",
-          "widgetType": "choice-picker",
+          "widgetType": "widget-choice-picker",
           "parameters": {
             "choices": "event-approval-choices"
           }
@@ -76,7 +76,7 @@
         {
           "label": "Submit",
           "description": "Submit this talk",
-          "widgetType": "approval-submit",
+          "widgetType": "widget-approval-submit",
           "parameters": {
             "item": "item",
             "approve": "event-approved",

--- a/workflow/schemas/meeting.json
+++ b/workflow/schemas/meeting.json
@@ -27,7 +27,7 @@
         {
           "label": "What kind of meeting event is this?",
           "description": "Select the kind of event that is being submitted. Events may be \"talk\" or \"poster\"",
-          "widgetType": "text-field",
+          "widgetType": "widget-text-field",
           "parameters": {
             "value": "event-kind"
           }
@@ -35,7 +35,7 @@
         {
           "label": "Title",
           "description": "Enter the title of the file.",
-          "widgetType": "text-field",
+          "widgetType": "widget-text-field",
           "parameters": {
             "value": "title-widget"
           }
@@ -43,7 +43,7 @@
         {
           "label": "Description",
           "description": "Add a brief description explaining what this talk or poster is about",
-          "widgetType": "text-area",
+          "widgetType": "widget-text-area",
           "parameters": {
             "value": "event-description"
           }
@@ -57,7 +57,7 @@
         {
           "label": "Use an existing node",
           "description": "Any materials related to this talk are stored in an OSF Project. Files are automatically uploaded to a new project. If a project containing the materials that are related to this talk already exists, that project may be selected instead of creating a new one. Click here to learn more about OSF projects. (This link will open in a new window.)",
-          "widgetType": "choice-picker",
+          "widgetType": "widget-choice-picker",
           "parameters": {
             "choices": "event-creation-choices"
           }
@@ -65,7 +65,7 @@
         {
           "label": "Node Create",
           "description": "Creates the node when its parameter 'enable' is set to true",
-          "widgetType": "node-creator",
+          "widgetType": "widget-node-creator",
           "parameters": {
             "enable": "create-new-node",
             "node": "node"
@@ -74,7 +74,7 @@
         {
           "label": "Upload Materials",
           "description": "Select the file to upload",
-          "widgetType": "file-uploader",
+          "widgetType": "widget-file-uploader",
           "parameters": {
             "fileData": "file-data",
             "fileName": "file-name"

--- a/workflow/schemas/preprint.json
+++ b/workflow/schemas/preprint.json
@@ -23,7 +23,7 @@
         {
           "label": "Preprint Title",
           "description": "Add the title of the preprint",
-          "widgetType": "text-field",
+          "widgetType": "widget-text-field",
           "parameters": {
             "value": "title"
           }
@@ -31,7 +31,7 @@
         {
           "label": "Abstract",
           "description": "Enter the abstract of the preprint",
-          "widgetType": "text-area",
+          "widgetType": "widget-text-area",
           "parameters": {
             "value": "abstract"
           }
@@ -39,7 +39,7 @@
         {
           "label": "DOI",
           "description": "If this preprint has a DOI, enter it.",
-          "widgetType": "text-field",
+          "widgetType": "widget-text-field",
           "parameters": {
             "value": "doi"
           }
@@ -53,7 +53,7 @@
         {
           "label": "Speakers",
           "description": "Select the names of the people that will be speaking at the talk or are authors of the poster.",
-          "widgetType": "osf-user-picker",
+          "widgetType": "widget-user-picker",
           "parameters": {
             "users": "authors"
           }
@@ -67,7 +67,7 @@
         {
           "label": "Use an existing node",
           "description": "Any materials related to this talk are stored in an OSF Project. Files are automatically uploaded to a new project. If a project containing the materials that are related to this talk already exists, that project may be selected instead of creating a new one. Click here to learn more about OSF projects. (This link will open in a new window.)",
-          "widgetType": "choice-picker",
+          "widgetType": "widget-choice-picker",
           "parameters": {
             "choices": "event-creation-choices"
           }
@@ -75,7 +75,7 @@
         {
           "label": "Node Create",
           "description": "Creates the node when its parameter 'enable' is set to true",
-          "widgetType": "node-creator",
+          "widgetType": "widget-node-creator",
           "parameters": {
             "enable": "create-new-node",
             "node": "node"
@@ -84,7 +84,7 @@
         {
           "label": "Upload Materials",
           "description": "Select the file to upload",
-          "widgetType": "file-uploader",
+          "widgetType": "widget-file-uploader",
           "parameters": {
             "fileData": "file-data",
             "fileName": "file-name"
@@ -99,7 +99,7 @@
         {
           "label": "Disciplines",
           "description": "Select the relevant disciplines. To remove a discipline, press the 'x' on the discipline plaquard.",
-          "widgetType": "subject-picker",
+          "widgetType": "widget-subject-picker",
           "parameters": {
             "subjects": "disciplines"
           }
@@ -113,7 +113,7 @@
         {
           "label": "License Type",
           "description": "Choose the license this preprint should be available under",
-          "widgetType": "text-field",
+          "widgetType": "widget-text-field",
           "parameters": {
             "value": "license-type"
           }
@@ -121,7 +121,7 @@
         {
           "label": "Copyright Year",
           "description": "Select the year of copyright",
-          "widgetType": "text-field",
+          "widgetType": "widgettext-field",
           "parameters": {
             "value": "copyright-year"
           }
@@ -129,7 +129,7 @@
         {
           "label": "Copyright Holders",
           "description": "Enter the copyright holders for the preprint's license",
-          "widgetType": "text-field",
+          "widgetType": "widgettext-field",
           "parameters": {
             "value": "copyright-holders"
           }
@@ -143,7 +143,7 @@
         {
           "label": "Submit",
           "description": "Submit this talk",
-          "widgetType": "preprint-submit",
+          "widgetType": "widget-preprint-submit",
           "parameters": {
             "title": "title-widget",
             "abstract": "abstract",


### PR DESCRIPTION
* All components that were previously referred to as layers are now referred to as sections
* All section component names are now prefixed with `section-`

* All workflow components with non-display logic are now referred to as widgets
* All widget component names are now prefixed with `widget-`

* These updates have been made for cleaner organization and to facilitate making changes to all of one of these component types at the same time, without missing any.